### PR TITLE
Precinct results table

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,13 +1,14 @@
 import React, { Component } from "react";
 import { gql } from "apollo-boost";
 import { Query } from "react-apollo";
-// import "../styles/App.css";
 import { Box } from "theme-ui";
+import styled from "@emotion/styled";
+// import "../styles/App.css";
 import { Layout } from "./Layout";
 import Nevada from "./Nevada";
 import Sankey from "./CorrelationSankey";
 import CorrelationMatrix from "./CorrelationMatrix";
-import styled from "@emotion/styled";
+import { PrecinctTable } from "./PrecinctTable";
 
 const Title = styled.h1`
   font-size: 35px;
@@ -46,6 +47,9 @@ class App extends Component {
                 </Box>
                 <Box sx={{ mt: 2, mx: "auto" }}>
                   <Sankey></Sankey>
+                </Box>
+                <Box sx={{ mt: 2, mx: "auto", width: "100%" }}>
+                  <PrecinctTable></PrecinctTable>
                 </Box>
               </>
             );

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -4,10 +4,6 @@ import { ThemeProvider, jsx, Box, Flex, Styled } from "theme-ui";
 import styled from "@emotion/styled";
 import { theme } from "../styles/theme";
 
-const AppBody = styled.div`
-  display: flex;
-  flex-direction: column;
-`;
 console.warn(theme);
 
 export const Layout = ({ children }) => {
@@ -18,7 +14,7 @@ export const Layout = ({ children }) => {
           flexDirection: "column"
         }}
       >
-        <header sx={{ bg: "primary", py: [2, 3] }}>
+        <header sx={{ bg: "primary", py: [2, 3], boxShadow: 2}}>
           <Styled.h1 sx={{ color: "background", px: [2, 5] }}>
             UglyCauc.us
           </Styled.h1>

--- a/src/components/PrecinctTable.js
+++ b/src/components/PrecinctTable.js
@@ -2,7 +2,7 @@
 import React from "react";
 import { jsx } from "theme-ui";
 import { precinctData, candidateDisplayName } from "../lib/precinctData";
-import { Styled, Box } from "theme-ui";
+import { Styled, Box, Button } from "theme-ui";
 
 const mockData = precinctData();
 
@@ -10,140 +10,204 @@ const boolToString = b => (b ? "Yes" : "No");
 
 export const PrecinctTable = ({ data = mockData }) => {
   const { name, result } = data;
+  const [showVotes, setShowVotes] = React.useState(true);
+  const [showRules, setShowRules] = React.useState(true);
+  const [showIssues, setShowIssues] = React.useState(true);
+
+  // TODO: consider making these toggles in each section and passing in the raw setter
+  // This way we could use useEffect() to set the initial show state based on local logic
+  // or we could just do that up here with our actual initial values
+  const toggleShowVotes = () => {
+    setShowVotes(!showVotes);
+  };
+  const toggleShowRules = () => {
+    setShowRules(!showRules);
+  };
+  const toggleShowIssues = () => {
+    setShowIssues(!showIssues);
+  };
 
   return (
     <Box sx={{ width: "100%" }}>
       <Styled.h3>{name}</Styled.h3>
       <Styled.table sx={{ width: "100%" }}>
-        <VotesSection result={result} />
-        <MetaSection result={result} />
-        <IssuesSection result={result} />
+        <VotesSection
+          show={showVotes}
+          toggleShow={toggleShowVotes}
+          result={result}
+        />
+        <RulesSection
+          show={showRules}
+          toggleShow={toggleShowRules}
+          result={result}
+        />
+        <IssuesSection
+          show={showIssues}
+          toggleShow={toggleShowIssues}
+          result={result}
+        />
       </Styled.table>
     </Box>
   );
 };
 
-const SectionHeader = ({ title, children }) => {
+const SectionHeader = ({ title, subtitle = "", toggleShow, show }) => {
   return (
-    <Styled.tr>
-      <Styled.th colSpan={children ? "1" : "5"}>
-        <Styled.h3>{title}</Styled.h3>
-      </Styled.th>
-      {children && children}
-    </Styled.tr>
+    <thead>
+      <Styled.tr>
+        <Styled.th colSpan="1">
+          <Styled.h3>{title}</Styled.h3>
+        </Styled.th>
+        <Styled.th sx={{textAlign: "right"}} colSpan="3">
+          <Styled.h4>{subtitle}</Styled.h4>
+        </Styled.th>
+        <Styled.th colSpan="3" sx={{textAlign: "right"}}>
+          <Button onClick={toggleShow}>{show ? "Hide" : "Show"}</Button>
+        </Styled.th>
+      </Styled.tr>
+    </thead>
   );
 };
 
-const VotesSection = ({ result }) => {
+const VotesSection = ({ result, show, toggleShow }) => {
   const allCandidateKeys = Object.keys(result.firstRoundVotes);
-  console.log(result);
-  return (
-    <>
-      <thead>
-        <SectionHeader title="Votes"></SectionHeader>
-        <Styled.tr>
-          <Styled.th>
-            <Styled.h5>Name</Styled.h5>
-          </Styled.th>
-          <Styled.th>
-            <Styled.h5>Round 1</Styled.h5>
-          </Styled.th>
-          <Styled.th>
-            <Styled.h5>Round 2</Styled.h5>
-          </Styled.th>
-          <Styled.th>
-            <Styled.h5>Expected SDEs</Styled.h5>
-          </Styled.th>
-          <Styled.th>
-            <Styled.h5>Actual SDEs</Styled.h5>
-          </Styled.th>
-        </Styled.tr>
-      </thead>
-      <tbody>
-        {allCandidateKeys.map(k => (
-          <Styled.tr key={k}>
-            <Styled.td>
-              <Styled.p>{candidateDisplayName(k) || k}</Styled.p>
-            </Styled.td>
-            <Styled.td>
-              <Styled.p key={k}>{result.firstRoundVotes[k]}</Styled.p>
-            </Styled.td>
-            <Styled.td>
-              <Styled.p key={k}>{result.secondRoundVotes[k]}</Styled.p>
-            </Styled.td>
-            <Styled.td>
-              <Styled.p key={k}>
-                {result.expectedOutcome.awardedSDEs[k]}
-              </Styled.p>
-            </Styled.td>
-            <Styled.td>
-              <Styled.p key={k}>{result.actualOutcome.awardedSDEs[k]}</Styled.p>
-            </Styled.td>
-          </Styled.tr>
-        ))}
-      </tbody>
-    </>
-  );
-};
 
-const MetaSection = ({ result }) => {
   return (
     <>
-      <thead>
-        <SectionHeader title="Weird Rules"></SectionHeader>
-        <Styled.tr>
-          <Styled.th colSpan="1" />
-          <Styled.th colSpan="2">
-            <Styled.h5>Expected</Styled.h5>
-          </Styled.th>
-          <Styled.th colSpan="2">
-            <Styled.h5>Actual</Styled.h5>
-          </Styled.th>
-        </Styled.tr>
-      </thead>
-      <tbody>
-        <Styled.tr>
-          <Styled.td colSpan="1">
-            <Styled.p>Coin Toss</Styled.p>
-          </Styled.td>
-          <Styled.td colSpan="2">
-            <Styled.p>{boolToString(result.expectedOutcome.coinToss)}</Styled.p>
-          </Styled.td>
-          <Styled.td colSpan="2">
-            <Styled.p>{boolToString(result.actualOutcome.coinToss)}</Styled.p>
-          </Styled.td>
-        </Styled.tr>
-        <Styled.tr>
-          <Styled.td colSpan="1">
-            <Styled.p>Duel</Styled.p>
-          </Styled.td>
-          <Styled.td colSpan="2">
-            <Styled.p>{boolToString(result.expectedOutcome.coinToss)}</Styled.p>
-          </Styled.td>
-          <Styled.td colSpan="2">
-            <Styled.p>{boolToString(result.actualOutcome.coinToss)}</Styled.p>
-          </Styled.td>
-        </Styled.tr>
-      </tbody>
-    </>
-  );
-};
-
-const IssuesSection = ({ result }) => {
-  return (
-    <>
-      <thead>
-        <SectionHeader title="Possible Issues"></SectionHeader>
-      </thead>
-      <tbody>
-        <tr>
-          <Styled.td colSpan="5">
-            {result.issues.map(iss => (
-              <Styled.p key={iss}>- {iss}</Styled.p>
+      <SectionHeader title="Votes" show={show} toggleShow={toggleShow} />
+      {show && (
+        <>
+          <thead>
+            <Styled.tr>
+              <Styled.th>
+                <Styled.h5>Name</Styled.h5>
+              </Styled.th>
+              <Styled.th>
+                <Styled.h5>Round 1</Styled.h5>
+              </Styled.th>
+              <Styled.th>
+                <Styled.h5>Round 2</Styled.h5>
+              </Styled.th>
+              <Styled.th>
+                <Styled.h5>Expected SDEs</Styled.h5>
+              </Styled.th>
+              <Styled.th>
+                <Styled.h5>Actual SDEs</Styled.h5>
+              </Styled.th>
+            </Styled.tr>
+          </thead>
+          <tbody>
+            {allCandidateKeys.map(k => (
+              <Styled.tr key={k}>
+                <Styled.td>
+                  <Styled.p>{candidateDisplayName(k) || k}</Styled.p>
+                </Styled.td>
+                <Styled.td>
+                  <Styled.p key={k}>{result.firstRoundVotes[k]}</Styled.p>
+                </Styled.td>
+                <Styled.td>
+                  <Styled.p key={k}>{result.secondRoundVotes[k]}</Styled.p>
+                </Styled.td>
+                <Styled.td>
+                  <Styled.p key={k}>
+                    {result.expectedOutcome.awardedSDEs[k]}
+                  </Styled.p>
+                </Styled.td>
+                <Styled.td>
+                  <Styled.p key={k}>
+                    {result.actualOutcome.awardedSDEs[k]}
+                  </Styled.p>
+                </Styled.td>
+              </Styled.tr>
             ))}
-          </Styled.td>
-        </tr>
-      </tbody>
+          </tbody>
+        </>
+      )}
+    </>
+  );
+};
+
+const RulesSection = ({ result, show, toggleShow }) => {
+  return (
+    <>
+      <SectionHeader
+        title="Caucus Rules"
+        show={show}
+        toggleShow={toggleShow}
+      ></SectionHeader>
+      {show && (
+        <>
+          <thead>
+            <Styled.tr>
+              <Styled.th colSpan="1" />
+              <Styled.th colSpan="2">
+                <Styled.h5>Expected</Styled.h5>
+              </Styled.th>
+              <Styled.th colSpan="2">
+                <Styled.h5>Actual</Styled.h5>
+              </Styled.th>
+            </Styled.tr>
+          </thead>
+          <tbody>
+            <Styled.tr>
+              <Styled.td colSpan="1">
+                <Styled.p>Coin Toss</Styled.p>
+              </Styled.td>
+              <Styled.td colSpan="2">
+                <Styled.p>
+                  {boolToString(result.expectedOutcome.coinToss)}
+                </Styled.p>
+              </Styled.td>
+              <Styled.td colSpan="2">
+                <Styled.p>
+                  {boolToString(result.actualOutcome.coinToss)}
+                </Styled.p>
+              </Styled.td>
+            </Styled.tr>
+            <Styled.tr>
+              <Styled.td colSpan="1">
+                <Styled.p>Duel</Styled.p>
+              </Styled.td>
+              <Styled.td colSpan="2">
+                <Styled.p>
+                  {boolToString(result.expectedOutcome.coinToss)}
+                </Styled.p>
+              </Styled.td>
+              <Styled.td colSpan="2">
+                <Styled.p>
+                  {boolToString(result.actualOutcome.coinToss)}
+                </Styled.p>
+              </Styled.td>
+            </Styled.tr>
+          </tbody>
+        </>
+      )}
+    </>
+  );
+};
+
+const IssuesSection = ({ result, show, toggleShow }) => {
+  const issueCount = result.issues.length
+  const subtitle = `${issueCount} issue${issueCount === 1 ? "" : "s"} identified`
+  return (
+    <>
+      <SectionHeader
+        title="Possible Issues"
+        subtitle={subtitle}
+        show={show}
+        toggleShow={toggleShow}
+      ></SectionHeader>
+      {show && (
+        <tbody>
+          <tr>
+            <Styled.td colSpan="5">
+              {result.issues.map(iss => (
+                <Styled.p key={iss}>- {iss}</Styled.p>
+              ))}
+            </Styled.td>
+          </tr>
+        </tbody>
+      )}
     </>
   );
 };

--- a/src/components/PrecinctTable.js
+++ b/src/components/PrecinctTable.js
@@ -1,0 +1,149 @@
+/** @jsx jsx */
+import React from "react";
+import { jsx } from "theme-ui";
+import { precinctData, candidateDisplayName } from "../lib/precinctData";
+import { Styled, Box } from "theme-ui";
+
+const mockData = precinctData();
+
+const boolToString = b => (b ? "Yes" : "No");
+
+export const PrecinctTable = ({ data = mockData }) => {
+  const { name, result } = data;
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      <Styled.h3>{name}</Styled.h3>
+      <Styled.table sx={{ width: "100%" }}>
+        <VotesSection result={result} />
+        <MetaSection result={result} />
+        <IssuesSection result={result} />
+      </Styled.table>
+    </Box>
+  );
+};
+
+const SectionHeader = ({ title, children }) => {
+  return (
+    <Styled.tr>
+      <Styled.th colSpan={children ? "1" : "5"}>
+        <Styled.h3>{title}</Styled.h3>
+      </Styled.th>
+      {children && children}
+    </Styled.tr>
+  );
+};
+
+const VotesSection = ({ result }) => {
+  const allCandidateKeys = Object.keys(result.firstRoundVotes);
+  console.log(result);
+  return (
+    <>
+      <thead>
+        <SectionHeader title="Votes"></SectionHeader>
+        <Styled.tr>
+          <Styled.th>
+            <Styled.h5>Name</Styled.h5>
+          </Styled.th>
+          <Styled.th>
+            <Styled.h5>Round 1</Styled.h5>
+          </Styled.th>
+          <Styled.th>
+            <Styled.h5>Round 2</Styled.h5>
+          </Styled.th>
+          <Styled.th>
+            <Styled.h5>Expected SDEs</Styled.h5>
+          </Styled.th>
+          <Styled.th>
+            <Styled.h5>Actual SDEs</Styled.h5>
+          </Styled.th>
+        </Styled.tr>
+      </thead>
+      <tbody>
+        {allCandidateKeys.map(k => (
+          <Styled.tr key={k}>
+            <Styled.td>
+              <Styled.p>{candidateDisplayName(k) || k}</Styled.p>
+            </Styled.td>
+            <Styled.td>
+              <Styled.p key={k}>{result.firstRoundVotes[k]}</Styled.p>
+            </Styled.td>
+            <Styled.td>
+              <Styled.p key={k}>{result.secondRoundVotes[k]}</Styled.p>
+            </Styled.td>
+            <Styled.td>
+              <Styled.p key={k}>
+                {result.expectedOutcome.awardedSDEs[k]}
+              </Styled.p>
+            </Styled.td>
+            <Styled.td>
+              <Styled.p key={k}>{result.actualOutcome.awardedSDEs[k]}</Styled.p>
+            </Styled.td>
+          </Styled.tr>
+        ))}
+      </tbody>
+    </>
+  );
+};
+
+const MetaSection = ({ result }) => {
+  return (
+    <>
+      <thead>
+        <SectionHeader title="Weird Rules"></SectionHeader>
+        <Styled.tr>
+          <Styled.th colSpan="1" />
+          <Styled.th colSpan="2">
+            <Styled.h5>Expected</Styled.h5>
+          </Styled.th>
+          <Styled.th colSpan="2">
+            <Styled.h5>Actual</Styled.h5>
+          </Styled.th>
+        </Styled.tr>
+      </thead>
+      <tbody>
+        <Styled.tr>
+          <Styled.td colSpan="1">
+            <Styled.p>Coin Toss</Styled.p>
+          </Styled.td>
+          <Styled.td colSpan="2">
+            <Styled.p>{boolToString(result.expectedOutcome.coinToss)}</Styled.p>
+          </Styled.td>
+          <Styled.td colSpan="2">
+            <Styled.p>{boolToString(result.actualOutcome.coinToss)}</Styled.p>
+          </Styled.td>
+        </Styled.tr>
+        <Styled.tr>
+          <Styled.td colSpan="1">
+            <Styled.p>Duel</Styled.p>
+          </Styled.td>
+          <Styled.td colSpan="2">
+            <Styled.p>{boolToString(result.expectedOutcome.coinToss)}</Styled.p>
+          </Styled.td>
+          <Styled.td colSpan="2">
+            <Styled.p>{boolToString(result.actualOutcome.coinToss)}</Styled.p>
+          </Styled.td>
+        </Styled.tr>
+      </tbody>
+    </>
+  );
+};
+
+const IssuesSection = ({ result }) => {
+  return (
+    <>
+      <thead>
+        <SectionHeader title="Possible Issues"></SectionHeader>
+      </thead>
+      <tbody>
+        <tr>
+          <Styled.td colSpan="5">
+            {result.issues.map(iss => (
+              <Styled.p key={iss}>- {iss}</Styled.p>
+            ))}
+          </Styled.td>
+        </tr>
+      </tbody>
+    </>
+  );
+};

--- a/src/lib/precinctData.js
+++ b/src/lib/precinctData.js
@@ -1,0 +1,59 @@
+const candidates = {
+  liz: "Warren",
+  pete: "BootEdgeEdge",
+  tulsi: "Gabbard",
+  joe: "Biden",
+  amy: "Klobuchar",
+  bernie: "Sanders",
+  mike: "Bloomberg"
+}
+
+const candidateKeys = Object.keys(candidates);
+console.warn(candidateKeys)
+/* TODO: unmock */
+const candidateVotes = _csvRow =>
+  candidateKeys.reduce((acc, key) => {
+    console.log(key, acc)
+    return ({
+      ...acc,
+      [key]: Math.floor(Math.random() * 1000)
+    })
+  }, {});
+
+const awardedSDEs = _csvRow =>
+  candidateKeys.reduce((acc, key) => ({
+    ...acc,
+    [key]: Math.floor(Math.random() * 100)
+  }), {});
+
+
+export const precinctData = () => ({
+  name: "Precinct X",
+  result: precinctResult()
+});
+
+export const candidateDisplayName = (key) => candidates[key]
+
+const precinctResult = row => {
+  const firstRoundVotes = candidateVotes(row);
+  const secondRoundVotes = candidateVotes(row);
+  return {
+    /* Reported first-round votes */
+    firstRoundVotes: candidateVotes(row),
+    /* Reported second-round votes */
+    secondRoundVotes: candidateVotes(row),
+    expectedOutcome: {
+      awardedSDEs: awardedSDEs(row),
+      coinToss: true // ?
+    },
+    actualOutcome: {
+      awardedSDEs: awardedSDEs(row),
+      coinToss: true
+    },
+    issues: [
+      "Bernie is not a real democrat",
+      "Nonviable candidates combined after 1st round",
+      "Amy Klobuchar is a cop"
+    ]
+  };
+};

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -12,34 +12,34 @@ const colors = {
     "4": "hsl(0,0%,68%)",
     "5": "hsl(0,0%,77%)",
     "6": "hsl(0,0%,85%)",
-    "7": "hsl(0,0%,93%)",
-  },
-}
+    "7": "hsl(0,0%,93%)"
+  }
+};
 
 const fontFamilies = {
   mono: "Fira Mono",
   sans: "Roboto, system-ui, sans-serif",
-  serif: "itc-american-typewriter, serif",
-}
+  serif: "itc-american-typewriter, serif"
+};
 
 const fonts = {
   ...fontFamilies,
   body: fontFamilies.serif,
-  heading: fontFamilies.serif,
-}
+  heading: fontFamilies.serif
+};
 
-export const theme  = {
+export const theme = {
   space: [0, 4, 8, 16, 32, 64, 128, 256, 512],
   fonts,
   fontSizes: [12, 14, 16, 20, 24, 32, 48, 64, 96],
   fontWeights: {
     body: 400,
     heading: 500,
-    bold: 700,
+    bold: 700
   },
   lineHeights: {
     body: 1.5,
-    heading: 1.125,
+    heading: 1.125
   },
   shadows: ["none", "inset 0 0 0 2px", "0 0 16px rgba(0, 0, 0, .25)"],
   colors: {
@@ -48,7 +48,7 @@ export const theme  = {
     text: colors.text,
     secondary: colors.secondary,
     primary: colors.blue,
-    muted: "#f1f3f4",
+    muted: "#f1f3f4"
   },
   radii: [0, 2, 3, 5, 10],
   styles: {
@@ -56,9 +56,9 @@ export const theme  = {
       fontFamily: "body",
       lineHeight: "body",
       fontWeight: "body",
-      'h1, h2, h3':{
-        fontFamily: 'heading',
-        lineHeight: 'heading'
+      "h1, h2, h3": {
+        fontFamily: "heading",
+        lineHeight: "heading"
       }
     },
     h1: {
@@ -66,74 +66,79 @@ export const theme  = {
       fontFamily: "heading",
       lineHeight: "1.2",
       fontWeight: "heading",
-      fontSize: 5,
+      fontSize: 5
     },
     h2: {
       color: "text",
       fontFamily: "heading",
       lineHeight: "1.2",
       fontWeight: "heading",
-      fontSize: 4,
+      fontSize: 4
     },
     h3: {
       color: "text",
       fontFamily: "heading",
       lineHeight: "1.2",
       fontWeight: "heading",
-      fontSize: 3,
+      fontSize: 3
     },
     h4: {
       color: "text",
       fontFamily: "heading",
       lineHeight: "1.2",
       fontWeight: "heading",
-      fontSize: 2,
+      fontSize: 2
     },
     h5: {
       color: "text",
       fontFamily: "heading",
       lineHeight: "1.2",
       fontWeight: "heading",
-      fontSize: 1,
+      fontSize: 1
     },
     h6: {
       color: "text",
       fontFamily: "heading",
       lineHeight: "1.2",
       fontWeight: "heading",
-      fontSize: 0,
+      fontSize: 0
     },
     p: {
       color: "text",
       fontFamily: "body",
       fontWeight: "body",
-      lineHeight: "body",
+      lineHeight: "body"
     },
     a: {
-      color: "primary",
+      color: "primary"
     },
     pre: {
       fontFamily: "monospace",
-      overflowX: "auto",
+      overflowX: "auto"
     },
     code: {
       fontFamily: "monospace",
-      fontSize: "inherit",
+      fontSize: "inherit"
     },
     table: {
       width: "100%",
       borderCollapse: "separate",
-      borderSpacing: 0,
+      borderSpacing: 0
     },
     th: {
       textAlign: "left",
       borderBottomStyle: "solid",
+      borderBottomWidth: "1px",
+      px: 1
     },
     td: {
       textAlign: "left",
       borderBottomStyle: "solid",
-    },
+      borderBottomWidth: "1px",
+      px: 1
+    }
   },
+  /* This section needs to be updated for theme-ui's newer interface */
   componentStyles: {
     Button: {
       display: "inline-block",
@@ -155,15 +160,15 @@ export const theme  = {
       borderRadius: 3,
       ":disabled": {
         bg: "gray.5",
-        color: "muted",
+        color: "muted"
       },
       variants: {
         outline: {
           color: "primary",
           bg: "background",
-          boxShadow: 1,
-        },
-      },
+          boxShadow: 1
+        }
+      }
     },
     Card: {
       p: 2,
@@ -172,20 +177,20 @@ export const theme  = {
       borderRadius: 2,
       variants: {
         shadow: {
-          boxShadow: 2,
-        },
-      },
+          boxShadow: 2
+        }
+      }
     },
     Heading: {
       lineHeight: "heading",
       fontWeight: "heading",
       fontFamily: "heading",
-      fontSize: 5,
+      fontSize: 5
     },
     Text: {
       lineHeight: "body",
       whiteSpace: "pre-wrap",
-      fontFamily: "body",
-    },
-  },
-}
+      fontFamily: "body"
+    }
+  }
+};


### PR DESCRIPTION
An initial table for precinct results with toggles for visibility and some skeleton fake data. We might want to change headers, rows, sections or add logic for what to automatically show/hide but i think this provides a good starting point.

One thing I did not do was protect for presence of data- we may want to add something like `_.get` for nested queries so we can safely dig into more generated data, or we can just be very careful about how we generate these objects. 

Current full table looks like this:
![image](https://user-images.githubusercontent.com/9088720/74609587-788e8780-50b9-11ea-992c-1688a202557a.png)
