### PR TITLE
display actual errors and select county by error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+EXTEND_ESLINT=true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "react-app",
+  "rules": {
+    "no-unused-vars": ["error", { "varsIgnorePattern": "^_" }]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .vscode/
+.env

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/lib/precinctData.js

--- a/src/components/Alerts.js
+++ b/src/components/Alerts.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import React from "react";
 import { jsx, Flex, Box, Styled } from "theme-ui";
-import { AppContext } from "./AppContext";
+import { UserContext } from "./Context";
 
 // 12 viable_loss          logical: if a candidate was viable in 1st round and lost votes going to final round
 // 13 nonviable_no_realign logical: if a nonviable candidate from 1st round did not realign in final round
@@ -78,7 +78,7 @@ export const Alert = ({ type, alert, onClick }) => {
 };
 
 export const Alerts = () => {
-  const { data, setSelectedPrecinct } = React.useContext(AppContext);
+  const { data, setSelectedPrecinct } = React.useContext(UserContext);
   const { alerts, warnings } = data;
 
   const allAlerts = groupedIssues(alerts, "alert");

--- a/src/components/Alerts.js
+++ b/src/components/Alerts.js
@@ -70,7 +70,7 @@ export const Alert = ({ type, alert, onClick }) => {
       }}
     >
       <Styled.h4 sx={{ color, my: 0 }}>
-        Precinct {precinct.precinctId}
+        Precinct {precinct["precinct_full"]}
       </Styled.h4>
       <Styled.p sx={{ color, mb: 0 }}>{alert.message}</Styled.p>
     </Box>

--- a/src/components/Alerts.js
+++ b/src/components/Alerts.js
@@ -1,36 +1,49 @@
 /** @jsx jsx */
 import React from "react";
 import { jsx, Flex, Box, Styled } from "theme-ui";
+import { AppContext } from "./AppContext";
 
-/**
- * interface Alert {
- *  type: 'warning' | 'error' | 'comment'
- *  message: string // human readable error
- *  code: string // the csv column code
- *  precinctId: the precinct GEOID10
- * }
- */
-const fakeAlertData = () => [
-  {
-    type: "warning",
-    message: "alphabetical shift in vote reporting detected",
-    code: "has_alpha_shift",
-    precinctId: "101"
-  },
-  {
-    type: "comment",
-    message:
-      "this is really more of a comment than an alert, i noticed that in paragraph 7 you specify a game of chance without acknowledging (all caucusgoers exit room)...",
-    code: "has_alpha_shift",
-    precinctId: "101"
-  },
-  {
-    type: "error",
-    message: "our delegate counts differ from those reported",
-    code: "del_counts_diff",
-    precinctId: "105"
-  }
-];
+// 12 viable_loss          logical: if a candidate was viable in 1st round and lost votes going to final round
+// 13 nonviable_no_realign logical: if a nonviable candidate from 1st round did not realign in final round
+// 14 alpha_shift          string: name of candidate that had alphabetical shift
+// 15 has_alpha_shift      logical: alphabetical shift in vote reporting detected. warning, not error
+// 16 more_final_votes     logical: more votes in final alignment than 1st alignment
+// 17 fewer_final_votes    logical: fewer votes in final alignment than 1st. warning, not error
+// 18 del_counts_diff      logical: our delegate counts differ from those reported
+// 19 extra_del_given      logical: too many delegates given out but all candidates had 1 delegate, so an extra delegate was given. warning, not error
+
+// for a given message type, a string or precinct => string function
+const messageMap = {
+  countySucks: precinct => `${precinct.county} sucks`,
+  viableLoss: "1st-round viable candidate lost votes in round 2",
+  nonviableNoRealign:
+    "1st-round nonviable candidate did not realign in round 2",
+  alphaShift: precinct =>
+    `Alphabetical shift in voting detected for ${precinct["has_alpha_shift"]}`,
+  moreFinalVotes: `More votes in final alignment than 1st alignment`,
+  fewerFinalVotes: `Fewer votes in final alignment than 1st alignment`,
+  delCountsDiff: "Our delegate counts differ from those reported",
+  extraDelGiven:
+    "Too many delegates given out but all candidates had 1 delegate, so an extra delegate was given"
+};
+
+const messageForIssueType = (key, precinct) => {
+  const message = messageMap[key] || key;
+  return typeof message === "function" ? message(precinct) : message;
+};
+
+// create an issue with key common data and precinct nested inside
+const groupedIssues = (issues, issueType) =>
+  Object.keys(issues).flatMap(key =>
+    issues[key].map(precinct => {
+      return {
+        precinct,
+        message: messageForIssueType(key, precinct),
+        type: issueType,
+        key
+      };
+    })
+  );
 
 const alertColorTheme = {
   warning: { background: "warning", color: "black" },
@@ -39,13 +52,12 @@ const alertColorTheme = {
 };
 const defaultColors = alertColorTheme.comment;
 
-export const Alert = ({ alert }) => {
-  const { background, color } = alertColorTheme[alert.type] || defaultColors;
+export const Alert = ({ type, alert, onClick }) => {
+  const { precinct } = alert;
+  const { background, color } = alertColorTheme[type] || defaultColors;
   return (
     <Box
-      onClick={() => {
-        console.log("focusing on precinct with the error");
-      }}
+      onClick={onClick}
       sx={{
         mt: 2,
         border: "2px solid",
@@ -57,16 +69,22 @@ export const Alert = ({ alert }) => {
         lineHeight: "1"
       }}
     >
-      <Styled.h4 sx={{ color, my: 0 }}>Precinct {alert.precinctId}</Styled.h4>
+      <Styled.h4 sx={{ color, my: 0 }}>
+        Precinct {precinct.precinctId}
+      </Styled.h4>
       <Styled.p sx={{ color, mb: 0 }}>{alert.message}</Styled.p>
     </Box>
   );
 };
 
 export const Alerts = () => {
-  const alerts = fakeAlertData();
+  const { data, setSelectedPrecinct } = React.useContext(AppContext);
+  const { alerts, warnings } = data;
 
-  console.warn("RENDERING ALERTS");
+  const allAlerts = groupedIssues(alerts, "alert");
+  const allWarnings = groupedIssues(warnings, "warning");
+  const allIssues = allAlerts.concat(allWarnings);
+  console.log(allIssues);
   return (
     <Flex
       sx={{
@@ -76,13 +94,72 @@ export const Alerts = () => {
       }}
     >
       <Styled.h2>Notable Votables</Styled.h2>
-      {alerts.length === 0 ? (
+      {allIssues.length === 0 ? (
         <Styled.p>Having a normal one</Styled.p>
       ) : (
-        alerts.map((a, i) => {
-          return <Alert key={i} alert={a} />;
+        allIssues.map(issue => {
+          return (
+            <Alert
+              key={
+                /* Should maybe be the GEOID10 as unique id */
+                issue.precinct["row_id"] + issue.key
+              }
+              alert={issue}
+              type={issue.type}
+              onClick={() => {
+                const precinctId = issue.precinct["GEOID10"];
+                console.log(
+                  "focusing on precinct with the error- " + precinctId
+                );
+                setSelectedPrecinct(precinctId);
+              }}
+            />
+          );
         })
       )}
     </Flex>
   );
 };
+
+// {
+//   "row_id": "13753",
+//   "county": "CARSON CITY",
+//   "precinct": "111",
+//   "precinct_full": "111",
+//   "precinct_delegates": "9",
+//   "candidate": "buttigiegp",
+//   "align1": "36",
+//   "alignfinal": "34",
+//   "FIPS Code": "510",
+//   "GEOID10": "NVc(\"CARSON CITY\", \"CHURCHILL\", \"CLARK\", \"DOUGLAS\", \"ELKO\", \"ESMERALDA\", \"EUREKA\", \"HUMBOLDT\", \"LANDER\", \"LINCOLN\", \"LYON\", \"MINERAL\", \"NYE\", \"PERSHING\", \"STOREY\", \"WASHOE\", \"WHITE PINE\")111",
+//   "total_align1": "79",
+//   "total_alignfinal": "78",
+//   "viability_threshold": "12",
+//   "viable1": "TRUE",
+//   "viablefinal": "TRUE",
+//   "viable_loss": "TRUE",
+//   "nonviable_no_realign": "FALSE",
+//   "alpha_shift": "NA",
+//   "has_alpha_shift": "NA",
+//   "more_final_votes": "FALSE",
+//   "fewer_final_votes": "TRUE",
+//   "caucus_formula_result": "3.8734",
+//   "after_rounding": "4",
+//   "total_del_after_rounding": "4",
+//   "final_del": "5",
+//   "total_final_del": "13",
+//   "distance_next": "NA",
+//   "farthest_rank": "1",
+//   "closest_rank": "1",
+//   "min_far_rank": "1",
+//   "is_farthest": "TRUE",
+//   "min_close_rank": "1",
+//   "is_closest": "TRUE",
+//   "how_many_farthest": "1",
+//   "how_many_closest": "1",
+//   "game_of_chance": "no_tie",
+//   "extra_del_given": "FALSE",
+//   "comments": "NA",
+//   "tie_winner": "NA",
+//   "tie_loser": "NA"
+// }

--- a/src/components/Alerts.js
+++ b/src/components/Alerts.js
@@ -52,7 +52,7 @@ const alertColorTheme = {
 };
 const defaultColors = alertColorTheme.comment;
 
-export const Alert = ({ type, alert, onClick }) => {
+export const Alert = ({ type, alert, onClick, selected }) => {
   const { precinct } = alert;
   const { background, color } = alertColorTheme[type] || defaultColors;
   return (
@@ -70,18 +70,20 @@ export const Alert = ({ type, alert, onClick }) => {
       }}
     >
       <Styled.h4 sx={{ color, my: 0 }}>
-        Precinct {precinct["precinct_full"]}
+        {selected ? "*" : ""}Precinct {precinct["precinct_full"]}
       </Styled.h4>
       <Styled.p sx={{ color, mb: 0 }}>{alert.message}</Styled.p>
     </Box>
   );
 };
 
-export const Alerts = () => {
-  const { data, setSelectedPrecinct } = React.useContext(UserContext);
+export const Alerts = ({ data }) => {
+  const { selectedPrecinct, setSelectedPrecinct } = React.useContext(
+    UserContext
+  );
   const { alerts, warnings } = data;
 
-  const allAlerts = groupedIssues(alerts, "alert");
+  const allAlerts = groupedIssues(alerts, "error");
   const allWarnings = groupedIssues(warnings, "warning");
   const allIssues = allAlerts.concat(allWarnings);
   console.log(allIssues);
@@ -97,21 +99,22 @@ export const Alerts = () => {
       {allIssues.length === 0 ? (
         <Styled.p>Having a normal one</Styled.p>
       ) : (
-        allIssues.map(issue => {
+        allIssues.map((issue, i) => {
+          const precinctIdentifier = issue.precinct["precinct_full"];
           return (
             <Alert
+              selected={precinctIdentifier === selectedPrecinct}
               key={
                 /* Should maybe be the GEOID10 as unique id */
-                issue.precinct["row_id"] + issue.key
+                precinctIdentifier + issue.key + i
               }
               alert={issue}
               type={issue.type}
               onClick={() => {
-                const precinctId = issue.precinct["GEOID10"];
                 console.log(
-                  "focusing on precinct with the error- " + precinctId
+                  "focusing on precinct with the error- " + precinctIdentifier
                 );
-                setSelectedPrecinct(precinctId);
+                setSelectedPrecinct(precinctIdentifier);
               }}
             />
           );

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,13 +1,16 @@
-import React, { Component } from "react";
+import React from "react";
 import { Box } from "theme-ui";
 import { massageResult } from "../lib/precinctData";
 import { Layout } from "./Layout";
 import { Main } from "./Main";
+import { AppContext } from "./AppContext";
 
 const App = () => {
   const [data, setData] = React.useState(null);
   const [loading, setLoading] = React.useState(true);
   const [_loadError, setLoadError] = React.useState(false);
+
+  const [selectedPrecinct, setSelectedPrecinct] = React.useState(null);
 
   const fetchData = () => {
     var request = new XMLHttpRequest();
@@ -17,7 +20,7 @@ const App = () => {
       if (this.status >= 200 && this.status < 400) {
         // Success!
         var data = massageResult(this.response);
-        console.log({data})
+        console.log({ data });
         setData(data);
         setLoading(false);
       } else {
@@ -32,21 +35,22 @@ const App = () => {
     request.send();
   };
 
-  
-
   React.useEffect(fetchData, []);
 
-
   return (
-    <Layout>
-      {loading ? (
-        <Box>Loading...</Box>
-      ) : data ? (
-        <Main data={data} />
-      ) : (
-        <Box>An unexpected error occurred</Box>
-      )}
-    </Layout>
+    <AppContext.Provider
+      value={{ data, selectedPrecinct, setSelectedPrecinct }}
+    >
+      <Layout>
+        {loading ? (
+          <Box>Loading...</Box>
+        ) : data ? (
+          <Main data={data} />
+        ) : (
+          <Box>An unexpected error occurred</Box>
+        )}
+      </Layout>
+    </AppContext.Provider>
   );
 };
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -3,7 +3,7 @@ import { Box } from "theme-ui";
 import { massageResult } from "../lib/precinctData";
 import { Layout } from "./Layout";
 import { Main } from "./Main";
-import { AppContext } from "./AppContext";
+import { UserContext } from "./Context";
 
 const App = () => {
   const [data, setData] = React.useState(null);
@@ -38,7 +38,7 @@ const App = () => {
   React.useEffect(fetchData, []);
 
   return (
-    <AppContext.Provider
+    <UserContext.Provider
       value={{ data, selectedPrecinct, setSelectedPrecinct }}
     >
       <Layout>
@@ -50,7 +50,7 @@ const App = () => {
           <Box>An unexpected error occurred</Box>
         )}
       </Layout>
-    </AppContext.Provider>
+    </UserContext.Provider>
   );
 };
 

--- a/src/components/AppContext.js
+++ b/src/components/AppContext.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+export const AppContext = React.createContext({
+  selectedPrecinct: () => {},
+  setSelectedPrecinct: () => {},
+  data: null
+});

--- a/src/components/AppContext.js
+++ b/src/components/AppContext.js
@@ -1,7 +1,0 @@
-import React from "react";
-
-export const AppContext = React.createContext({
-  selectedPrecinct: () => {},
-  setSelectedPrecinct: () => {},
-  data: null
-});

--- a/src/components/Context.js
+++ b/src/components/Context.js
@@ -1,0 +1,6 @@
+import React from "react";
+
+export const UserContext = React.createContext({
+  selectedPrecinct: () => {},
+  setSelectedPrecinct: () => {}
+});

--- a/src/components/CorrelationMatrix.js
+++ b/src/components/CorrelationMatrix.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from "react";
+import React from "react";
 import styled from "@emotion/styled";
 import Biden from "../assets/Biden.gif";
 import Warren from "../assets/Warren.gif";
@@ -35,7 +35,7 @@ const Matrix = styled.div`
   flex-direction: column;
 `;
 
-export default function CorrelationMatrix(props) {
+export default function CorrelationMatrix(_props) {
   let candidates = {
     BootEdgeEdge,
     Klobuchar,
@@ -62,6 +62,8 @@ export default function CorrelationMatrix(props) {
           <Cell />
           {header.map(cell => (
             <img
+              key={cell}
+              alt={cell}
               src={candidates[cell]}
               width="60px"
               height="60px"
@@ -77,6 +79,8 @@ export default function CorrelationMatrix(props) {
                 return i == 0 ? (
                   <Cell>
                     <img
+                      key={i}
+                      alt={cell}
                       src={candidates[row.name]}
                       width="60px"
                       height="60px"

--- a/src/components/CorrelationSankey.js
+++ b/src/components/CorrelationSankey.js
@@ -1,70 +1,80 @@
-import React, { useRef, useEffect } from 'react'
-import * as d3 from 'd3';
-import { sankey as d3Sankey, sankeyLinkHorizontal} from 'd3-sankey';
-import Biden from '../assets/Biden.gif';
-import Warren from '../assets/Warren.gif';
-import Gabbard from '../assets/Gabbard.gif';
-import Klobuchar from '../assets/Klobuchar.gif';
-import BootEdgeEdge from '../assets/BootEdgeEdge.gif';
+import React, { useRef } from "react";
+import { sankey as d3Sankey, sankeyLinkHorizontal } from "d3-sankey";
+import Biden from "../assets/Biden.gif";
+import Warren from "../assets/Warren.gif";
+import Gabbard from "../assets/Gabbard.gif";
+import Klobuchar from "../assets/Klobuchar.gif";
+import BootEdgeEdge from "../assets/BootEdgeEdge.gif";
 
-export default function CorellationSankey(props) {
-    
-    let sankeyContainer = useRef(null);
-    let candidatees = {
-        BootEdgeEdge,
-        Klobuchar,
-        Gabbard,
-        Warren,
-        Biden };
+export default function CorellationSankey(_props) {
+  let sankeyContainer = useRef(null);
+  let candidatees = {
+    BootEdgeEdge,
+    Klobuchar,
+    Gabbard,
+    Warren,
+    Biden
+  };
 
-    let width = 600,
-        height = 200;
-          
-    let sankey = d3Sankey()
-      .nodeWidth(50)
-      .nodePadding(75)
-      .size([width, height]);
+  let width = 600,
+    height = 200;
 
-    let graph = sankey({
-        "nodes":[
-            {"node":0,"name":"Warren"},
-            {"node":1,"name":"BootEdgeEdge"},
-            {"node":2,"name":"Gabbard"},
-            {"node":3,"name":"Biden"},
-            {"node":4,"name":"Klobuchar"}
-        ],
-        "links":[
-            {"source":0,"target":2,"value":2},
-            {"source":1,"target":2,"value":2,  "suss":true},
-            {"source":1,"target":3,"value":2},
-            {"source":0,"target":3,"value":2},
-            {"source":2,"target":4,"value":2},
-            {"source":2,"target":4,"value":2},
-            {"source":3,"target":4,"value":4,}
-    ]});
+  let sankey = d3Sankey()
+    .nodeWidth(50)
+    .nodePadding(75)
+    .size([width, height]);
 
-    let links = graph.links;
-    let nodes = graph.nodes;
-    let svgLinks = links.map(link => {
-      return <g fill="none" stroke={link.suss ? "#f11": "#000"} strokeOpacity="0.2"><path d={sankeyLinkHorizontal()(link)} strokeWidth={link.width }></path></g>
-    })
-    let svgNodes = nodes.map(node => (
-        <g>
-            <image href={candidatees[node.name]} x={node.x0} y={node.y0} height={node.y1 - node.y0}  className="node"> </image>       
-        </g>
-    ));
-   
+  let graph = sankey({
+    nodes: [
+      { node: 0, name: "Warren" },
+      { node: 1, name: "BootEdgeEdge" },
+      { node: 2, name: "Gabbard" },
+      { node: 3, name: "Biden" },
+      { node: 4, name: "Klobuchar" }
+    ],
+    links: [
+      { source: 0, target: 2, value: 2 },
+      { source: 1, target: 2, value: 2, suss: true },
+      { source: 1, target: 3, value: 2 },
+      { source: 0, target: 3, value: 2 },
+      { source: 2, target: 4, value: 2 },
+      { source: 2, target: 4, value: 2 },
+      { source: 3, target: 4, value: 4 }
+    ]
+  });
+
+  let links = graph.links;
+  let nodes = graph.nodes;
+  let svgLinks = links.map(link => {
     return (
-        <svg
-            className="d3-component"
-            width={620}
-            height={200}
-            ref={sankeyContainer}
-        >
-        {svgLinks}
-        {svgNodes}
-        
-        </svg>
+      <g fill="none" stroke={link.suss ? "#f11" : "#000"} strokeOpacity="0.2">
+        <path d={sankeyLinkHorizontal()(link)} strokeWidth={link.width}></path>
+      </g>
     );
-     
-  }
+  });
+  let svgNodes = nodes.map(node => (
+    <g>
+      <image
+        href={candidatees[node.name]}
+        x={node.x0}
+        y={node.y0}
+        height={node.y1 - node.y0}
+        className="node"
+      >
+        {" "}
+      </image>
+    </g>
+  ));
+
+  return (
+    <svg
+      className="d3-component"
+      width={620}
+      height={200}
+      ref={sankeyContainer}
+    >
+      {svgLinks}
+      {svgNodes}
+    </svg>
+  );
+}

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -11,15 +11,21 @@ export const Layout = ({ children }) => {
           flexDirection: "column"
         }}
       >
-        <header sx={{ bg: "muted", py: [2, 3] }}>
+        <header sx={{ bg: "background", p: [2, 3], textAlign: "center" }}>
           <Styled.h1
-            sx={{ textDecoration: "underline", color: "gray.1", px: [2, 5] }}
+            sx={{
+              textDecoration: "underline",
+              color: "gray.1",
+              px: [2, 5],
+              fontWeight: 4
+            }}
           >
             UglyCauc.us
           </Styled.h1>
-          <marquee scrollamount="10">
-            <Styled.p sx={{ color: "gray.2" }}>Cranks Investigate ...</Styled.p>
-          </marquee>
+
+          <Styled.h3 sx={{ color: "gray.2" }}>
+            Analyzing the Nevada Caucus results in real time
+          </Styled.h3>
         </header>
         <main
           sx={{

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -1,5 +1,4 @@
 /** @jsx jsx */
-import React from "react";
 import { jsx, Flex, Box } from "theme-ui";
 import Nevada from "./Nevada";
 import { Alerts } from "./Alerts";

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -26,13 +26,14 @@ export const Main = ({ data }) => {
       {/* Center panel */}
       <Box
         sx={{
+          minWidth: "400px",
           borderLeft: "1px solid",
           borderColor: "gray.1",
           mt: [2, 0],
           p: [2, 3]
         }}
       >
-        <Nevada data={[1, 2, 3]}></Nevada> 
+        <Nevada data={[1, 2, 3]}></Nevada>
         <PrecinctTable />
       </Box>
       {/* Right panel */}

--- a/src/components/Nevada.js
+++ b/src/components/Nevada.js
@@ -1,11 +1,11 @@
 import React, { useRef, useEffect } from "react";
 import * as d3 from "d3";
 import { Box } from "theme-ui";
-import { AppContext } from "./AppContext";
+import { UserContext } from "./Context";
 
 export default function Nevada() {
   const { setSelectedPrecinct, selectedPrecinct } = React.useContext(
-    AppContext
+    UserContext
   );
 
   const [nevada, setNevada] = React.useState(null);

--- a/src/components/Nevada.js
+++ b/src/components/Nevada.js
@@ -1,173 +1,202 @@
-import React, {
-    useRef,
-    useEffect
-} from 'react'
-import * as d3 from 'd3';
-import {
-    Box
-} from "theme-ui";
-
+import React, { useRef, useEffect } from "react";
+import * as d3 from "d3";
+import { Box } from "theme-ui";
+import { AppContext } from "./AppContext";
 
 export default function Nevada() {
+  const { setSelectedPrecinct, selectedPrecinct } = React.useContext(
+    AppContext
+  );
 
-    const [nevada, setNevada] = React.useState(null);
-    const [loading, setLoading] = React.useState(true);
-    const [_loadError, setLoadError] = React.useState(false);
+  const [nevada, setNevada] = React.useState(null);
+  const [loading, setLoading] = React.useState(true);
+  const [_loadError, setLoadError] = React.useState(false);
 
-    const fetchGeoJson = () => {
-        var request = new XMLHttpRequest();
-        request.open("GET", "https://nevada-cranks.herokuapp.com/nevada", true);
+  const fetchGeoJson = () => {
+    var request = new XMLHttpRequest();
+    request.open("GET", "https://nevada-cranks.herokuapp.com/nevada", true);
 
-        request.onload = function() {
-            if (this.status >= 200 && this.status < 400) {
-                // Success!
-                var geojson = this.response;
-                console.log()
-                setNevada({
-                    geojson
-                });
-                setLoading(false);
-            } else {
-                setLoadError(true);
-                setLoading(false);
-                console.warn("server error");
-            }
-        };
-        request.onerror = function() {
-            console.warn("Nevada JSON not loading");
-        };
-        request.send();
+    request.onload = function() {
+      if (this.status >= 200 && this.status < 400) {
+        // Success!
+        var geojson = this.response;
+        console.log();
+        setNevada({
+          geojson
+        });
+        setLoading(false);
+      } else {
+        setLoadError(true);
+        setLoading(false);
+        console.warn("server error");
+      }
     };
+    request.onerror = function() {
+      console.warn("Nevada JSON not loading");
+    };
+    request.send();
+  };
 
-    React.useEffect(fetchGeoJson, []);
+  React.useEffect(fetchGeoJson, []);
 
+  let nevadaD3Container = useRef(null);
 
-    let nevadaD3Container = useRef(null);
+  useEffect(() => {
+    console.log({
+      loading,
+      nevada: !!nevada,
+      nevadaD3Container: nevadaD3Container.current
+    });
+    if (!!nevada && !!nevadaD3Container.current) {
+      console.log({
+        nevada
+      });
 
-    useEffect(
-        () => {
-            console.log({
-                loading,
-                nevada: !!nevada,
-                nevadaD3Container: nevadaD3Container.current
-            })
-            if (!!nevada && !!nevadaD3Container.current) {
-                console.log('here?')
-                console.log({
-                    nevada
-                });
+      let nevadaJson = JSON.parse(nevada.geojson);
+      console.log({
+        nevadaJson
+      });
 
-                let nevadaJson = JSON.parse(nevada.geojson);
-                console.log({
-                    nevadaJson
-                })
+      const svg = d3.select(nevadaD3Container.current);
 
-                const svg = d3.select(nevadaD3Container.current);
+      let width = 600;
+      let height = 600;
 
+      var projection = d3
+        .geoAlbers()
+        .scale(4500)
+        .rotate([116.4194, 0]) //latitude
+        .center([0, 38.8026]) //longitude
+        .translate([width / 2, height / 2]);
 
-                let width = 600;
-                let height = 600;
+      var _geoGenerator = d3
+        .geoPath()
+        .pointRadius(5)
+        .projection(projection);
 
-                var projection = d3.geoAlbers()
-                    .scale(4500)
-                    .rotate([116.4194, 0]) //latitude
-                    .center([0, 38.8026]) //longitude
-                    .translate([width / 2, height / 2]);
+      function reset() {
+        setSelectedPrecinct(null);
+        nevadaPath
+          .transition()
+          .duration(750)
+          .attr(
+            "transform",
+            "translate(" +
+              width / 2 +
+              "," +
+              height / 2 +
+              ")scale(" +
+              1 +
+              ")translate(" +
+              -300 +
+              "," +
+              -300 +
+              ")"
+          )
+          .style("stroke-width", 0.2 + "px");
+      }
+      d3.select("button").on("click", reset);
 
+      function clicked(d, t, e) {
+        var path = d3.geoPath().projection(projection);
+        var centroid = path.centroid(d);
+        let x = centroid[0];
+        let y = centroid[1];
+        let largestDimension = Math.max(
+          Math.abs(path.bounds(d)[1][1] - path.bounds(d)[0][1]),
+          Math.abs(path.bounds(d)[1][0] - path.bounds(d)[0][0])
+        );
+        var scale = d3.scaleLinear([0, largestDimension], [0.0, 4.0]);
+        let k = scale(50);
 
-                var geoGenerator = d3.geoPath()
-                    .pointRadius(5)
-                    .projection(projection);
+        nevadaPath
+          .transition()
+          .duration(750)
+          .attr(
+            "transform",
+            "translate(" +
+              width / 2 +
+              "," +
+              height / 2 +
+              ")scale(" +
+              k +
+              ")translate(" +
+              -x +
+              "," +
+              -y +
+              ")"
+          )
+          .style("stroke-width", 1.5 / k + "px");
+      }
 
+      function handleMouseOver(d, t, e) {
+        var path = d3.geoPath().projection(projection);
+        var centroid = path.centroid(d);
+        let x = centroid[0];
+        let y = centroid[1];
+        let k = 4;
 
+        d3.select(this).attr("fill", "url(#diagonal-stripe-2)");
+      }
 
-                function reset() {
-                    nevadaPath.transition()
-                        .duration(750)
-                        .attr("transform", "translate(" + width / 2 + "," + height / 2 + ")scale(" + 1 + ")translate(" + -300 + "," + -300 + ")")
-                        .style("stroke-width", .2 + "px")
-                }
-                d3.select("button")
-                    .on("click", reset);
+      function handleMouseOut(d, t, e) {
+        d3.select(this).attr("fill", "white");
+      }
 
+      let nevadaPath = svg
+        .append("g")
+        .selectAll("path")
+        .data(nevadaJson.features)
+        .enter()
+        .append("path")
+        .attr("d", d3.geoPath().projection(projection));
+      nevadaPath
+        .attr("stroke", "black")
+        .attr("stroke-width", ".5px")
+        .attr("fill", "white")
+        .on("mouseover", handleMouseOver)
+        .on("mouseout", handleMouseOut)
+        .on("click", clicked);
+    }
+  }, [loading, nevada, nevadaD3Container.current]);
 
-                function clicked(d, t, e) {
-                    var path = d3.geoPath()
-                        .projection(projection);
-                    var centroid = path.centroid(d);
-                    let x = centroid[0];
-                    let y = centroid[1];
-                    let largestDimension = Math.max(
-                        Math.abs(path.bounds(d)[1][1] - path.bounds(d)[0][1]), 
-                        Math.abs(path.bounds(d)[1][0] - path.bounds(d)[0][0])
-                    );
-                    var scale = d3.scaleLinear([0, largestDimension], [0.0, 4.0]);
-                    let k = scale(50);
-
-                    nevadaPath.transition()
-                        .duration(750)
-                        .attr("transform", "translate(" + width / 2 + "," + height / 2 + ")scale(" + k + ")translate(" + -x + "," + -y + ")")
-                        .style("stroke-width", 1.5 / k + "px");
-                }
-
-                function handleMouseOver(d, t, e) {
-                    var path = d3.geoPath()
-                        .projection(projection);
-                    var centroid = path.centroid(d);
-                    let x = centroid[0];
-                    let y = centroid[1];
-                    let k = 4;
-
-                    d3.select(this).attr('fill', "url(#diagonal-stripe-2)");
-                }
-
-                function handleMouseOut(d, t, e) {
-                    d3.select(this)
-                        .attr('fill', "white")
-                }
-
-                let nevadaPath = svg
-                    .append("g")
-                    .selectAll("path")
-                    .data(nevadaJson.features)
-                    .enter()
-                    .append("path")
-                    .attr("d", d3.geoPath()
-                        .projection(projection));
-                nevadaPath.attr('stroke', "black")
-                    .attr('stroke-width', '.5px')
-                    .attr("fill", "white")
-                    .on('mouseover', handleMouseOver)
-                    .on("mouseout", handleMouseOut)
-                    .on("click", clicked)
-
-            }
-        },
-        [loading, nevada, nevadaD3Container.current])
-
-    return (
+  return (
     <React.Fragment>
-        <button style={{ position:'relative', top:50, left:500}}>ZOOM OUT</button>
-    <div>
-    {loading ? (
-       <Box>Loading...</Box>
-     ) : nevada ? (
-        <svg
-        className="d3-component"
-        width={600}
-        height={600}
-        ref={nevadaD3Container}
-    >
-    <defs> <pattern id="diagonal-stripe-2" patternUnits="userSpaceOnUse" width="10" height="10">
-     <image xlinkHref="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPScxMCcgaGVpZ2h0PScxMCc+CiAgPHJlY3Qgd2lkdGg9JzEwJyBoZWlnaHQ9JzEwJyBmaWxsPSd3aGl0ZScvPgogIDxwYXRoIGQ9J00tMSwxIGwyLC0yCiAgICAgICAgICAgTTAsMTAgbDEwLC0xMAogICAgICAgICAgIE05LDExIGwyLC0yJyBzdHJva2U9J2JsYWNrJyBzdHJva2Utd2lkdGg9JzInLz4KPC9zdmc+" x="0" y="0" width="10" height="10"/>  
-      </pattern> 
-    </defs>
-    </svg>
-     ) : (
-      <Box>An unexpected error occurred</Box>
-     )}
-    </div>
+      <button style={{ position: "relative", top: 50, left: 500 }}>
+        ZOOM OUT
+      </button>
+      <div>
+        {loading ? (
+          <Box>Loading...</Box>
+        ) : nevada ? (
+          <svg
+            className="d3-component"
+            width={600}
+            height={600}
+            ref={nevadaD3Container}
+          >
+            <defs>
+              {" "}
+              <pattern
+                id="diagonal-stripe-2"
+                patternUnits="userSpaceOnUse"
+                width="10"
+                height="10"
+              >
+                <image
+                  xlinkHref="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPScxMCcgaGVpZ2h0PScxMCc+CiAgPHJlY3Qgd2lkdGg9JzEwJyBoZWlnaHQ9JzEwJyBmaWxsPSd3aGl0ZScvPgogIDxwYXRoIGQ9J00tMSwxIGwyLC0yCiAgICAgICAgICAgTTAsMTAgbDEwLC0xMAogICAgICAgICAgIE05LDExIGwyLC0yJyBzdHJva2U9J2JsYWNrJyBzdHJva2Utd2lkdGg9JzInLz4KPC9zdmc+"
+                  x="0"
+                  y="0"
+                  width="10"
+                  height="10"
+                />
+              </pattern>
+            </defs>
+          </svg>
+        ) : (
+          <Box>An unexpected error occurred</Box>
+        )}
+      </div>
     </React.Fragment>
-    );
-     
-  }
+  );
+}

--- a/src/lib/precinctData.js
+++ b/src/lib/precinctData.js
@@ -12,8 +12,8 @@ export const massageResult = csv => {
     let precinctGroup = _.groupBy(county, 'precinct');
       precinctGroup = _.reduce(precinctGroup, function(precinctResult, precinct, key) {
         let candidate = _.groupBy(precinct, 'candidate');
-          precinctResult[key] = _.reduce(candidate, function (candidateResult, c, canidateKey){
-            candidateResult[canidateKey] = c[0]; // In the future we can reduce this to a sparser model here.
+          precinctResult[key] = _.reduce(candidate, function (candidateResult, c, candidateKey){
+            candidateResult[candidateKey] = c[0]; // In the future we can reduce this to a sparser model here.
             return candidateResult;
           }, {})  
         return precinctResult;
@@ -29,6 +29,8 @@ export const massageResult = csv => {
   function toWarnings(row){
     return row;  //adapt model however we like.
   }
+
+
  
   function isFalse(row,prop){
     if(!row[prop]){
@@ -47,8 +49,8 @@ export const massageResult = csv => {
   let fewerFinalVotes = _.filter(jsResults, row => !isFalse(row,'fewer_final_votes')).map(toWarnings);
   let extraDelGiven = _.filter(jsResults, row => !isFalse(row,'extra_del_given')).map(toWarnings);
 
-  let alerts = [viableLoss, moreFinalVotes, nonviableNoRealign];
-  let warnings = [delCountsDiff, hasAlphaShift, fewerFinalVotes, extraDelGiven];
+  let alerts = {viableLoss, moreFinalVotes, nonviableNoRealign}
+  let warnings = {delCountsDiff, hasAlphaShift, fewerFinalVotes, extraDelGiven};
 
 
   return {electionData, alerts, warnings};


### PR DESCRIPTION
Adds some rudimentary logic for displaying alerts. This includes a helper for generating a custom error message for each precinct/alert. Please take a look and let me know if it makes sense to you

Using the current CSV (appears to be about 31k precinct errors) performance is very bad, and when selecting a precinct it causes the calculation to run again. I've tried to avoid some of this using React.memo and it hasn't really helped.

Clicking an error selects the affected precinct but it takes a LONG time for this to render the first time or on update (see the *) below. 

![image](https://user-images.githubusercontent.com/9088720/74944473-19d05300-53c4-11ea-9d23-1fa02a40c797.png)

